### PR TITLE
#164501895 implement fetch all unread emails

### DIFF
--- a/Server/Controllers/messageControllers.js
+++ b/Server/Controllers/messageControllers.js
@@ -19,11 +19,19 @@ class EpicMessage {
     });
   }
 
-  static allMessage(req, res) {
+  static receivedMessage(req, res) {
     const receivedMessages = messages.filter(message => (message.status === 'read' || message.status === 'unread'));
     res.status(200).json({
       status: 200,
       data: receivedMessages,
+    });
+  }
+
+  static unreadMessage(req, res) {
+    const unreadMessages = messages.filter(message => (message.status === 'unread'));
+    res.status(200).json({
+      status: 200,
+      data: unreadMessages,
     });
   }
 }

--- a/Server/Router/router.js
+++ b/Server/Router/router.js
@@ -10,6 +10,7 @@ router.get('/', Controller.welcome);
 router.post('/auth/signup', Validator.validateSignup, Controller.signup);
 router.post('/auth/login', Validator.validateLogin, Controller.login);
 router.post('/messages', Validator.validateMessage, messageController.newMessage);
-router.get('/messages', messageController.allMessage);
+router.get('/messages', messageController.receivedMessage);
+router.get('/messages/unread', messageController.unreadMessage);
 
 export default router;

--- a/Server/Test/test.js
+++ b/Server/Test/test.js
@@ -102,9 +102,22 @@ describe('Epic Test', () => {
   });
 
   describe('GET/messages', () => {
-    it('should send all messages', (done) => {
+    it('should respond with all received messages', (done) => {
       chai.request(app)
         .get('/api/v1/messages')
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(200);
+          expect(res.body.status).to.equal(200);
+          expect(res.body.data).to.be.an('array');
+          done();
+        });
+    });
+  });
+
+  describe('GET/messages/unread', () => {
+    it('should respond with all unread received messages', (done) => {
+      chai.request(app)
+        .get('/api/v1/messages/unread')
         .end((err, res) => {
           expect(res.statusCode).to.equal(200);
           expect(res.body.status).to.equal(200);


### PR DESCRIPTION
#### Description of Task to be completed?
1. Have the GET '/api/v1/messages/unread'  endpoint working

#### How should this be manually tested?
After cloning the repo, cd into it and run "npm run startdev",
Using postman test the endpoint with a GET method.

You'll get a response with status code of 200 and data with the unread messages.

#### What are the relevant pivotal tracker stories?
<a href = "https://www.pivotaltracker.com/story/show/164501895">#164501895</a>
