### PR TITLE
#164502658 implement fetch all sent messages endpoint

### DIFF
--- a/Server/Controllers/messageControllers.js
+++ b/Server/Controllers/messageControllers.js
@@ -34,6 +34,14 @@ class EpicMessage {
       data: unreadMessages,
     });
   }
+
+  static sentMessage(req, res) {
+    const sentMessages = messages.filter(message => (message.status === 'sent'));
+    res.status(200).json({
+      status: 200,
+      data: sentMessages,
+    });
+  }
 }
 
 export default EpicMessage;

--- a/Server/Router/router.js
+++ b/Server/Router/router.js
@@ -12,5 +12,6 @@ router.post('/auth/login', Validator.validateLogin, Controller.login);
 router.post('/messages', Validator.validateMessage, messageController.newMessage);
 router.get('/messages', messageController.receivedMessage);
 router.get('/messages/unread', messageController.unreadMessage);
+router.get('/messages/sent', messageController.sentMessage);
 
 export default router;

--- a/Server/Test/test.js
+++ b/Server/Test/test.js
@@ -126,4 +126,17 @@ describe('Epic Test', () => {
         });
     });
   });
+
+  describe('GET/messages/sent', () => {
+    it('should respond with all sent messages', (done) => {
+      chai.request(app)
+        .get('/api/v1/messages/sent')
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(200);
+          expect(res.body.status).to.equal(200);
+          expect(res.body.data).to.be.an('array');
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
Implements fetch all sent messages endpoint.

#### Description of Task to be completed?
1. Have the "GET "/api/v1/messages/sent" endpoint working

#### How should this be manually tested?
After cloning the repo, cd into it and run "npm run startdev",
Using postman test the endpoint with a GET method.

You'll get a response with status code of 200 and data with all sent messages.

#### What are the relevant pivotal tracker stories?
<a href = "https://www.pivotaltracker.com/story/show/164502658">#164502658</a>
