### PR TITLE
#164503400: implement delete an email endpoint

### DIFF
--- a/Server/Controllers/messageControllers.js
+++ b/Server/Controllers/messageControllers.js
@@ -55,6 +55,19 @@ class EpicMessage {
       data: message,
     });
   }
+
+  static deleteMessage(req, res) {
+    const messageId = req.params.id;
+    const messageObj = messages[messageId - 1];
+    if (!messageObj) {
+      return errorResponse(400, 'message does not exist', res);
+    }
+    delete messages[messageId];
+    return res.status(200).json({
+      status: 200,
+      data: { message: messageObj.message },
+    });
+  }
 }
 
 export default EpicMessage;

--- a/Server/Router/router.js
+++ b/Server/Router/router.js
@@ -14,5 +14,6 @@ router.get('/messages', messageController.receivedMessage);
 router.get('/messages/unread', messageController.unreadMessage);
 router.get('/messages/sent', messageController.sentMessage);
 router.get('/messages/:id', messageController.specificMessage);
+router.delete('/messages/:id', messageController.deleteMessage);
 
 export default router;

--- a/Server/Test/test.js
+++ b/Server/Test/test.js
@@ -164,4 +164,27 @@ describe('Epic Test', () => {
         });
     });
   });
+
+  describe('DELETE/messages/:id', () => {
+    it('should delete an email on valid message id', (done) => {
+      chai.request(app)
+        .delete('/api/v1/messages/5')
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(200);
+          expect(res.body.status).to.equal(200);
+          expect(res.body.data).to.be.an('object');
+          done();
+        });
+    });
+
+    it('should respond with an error on invalid message id', (done) => {
+      chai.request(app)
+        .get('/api/v1/messages/tbvryr4')
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(400);
+          expect(res.body.status).to.equal(400);
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
Implements delete an email endpoint.

#### Description of Task to be completed?
1. Have the "DELETE"/api/v1/messages/<message-id>" endpoint working

#### How should this be manually tested?
After cloning the repo, cd into it and run "npm run startdev",
Using postman test the endpoint with a DELETE method.

You'll get a response with status code of 200 and data with the deleted email "message" value.

#### What are the relevant pivotal tracker stories?
<a href = "https://www.pivotaltracker.com/story/show/164503400">#164503400</a>
