### PR TITLE
#164685665-implement feature for an admin to delete a group

### DIFF
--- a/Server/Controllers/groupController.js
+++ b/Server/Controllers/groupController.js
@@ -66,6 +66,26 @@ class EpicGroup {
 
     return errorResponse(401, 'Unauthorized access', res);
   }
+
+  static async deleteGroup(req, res) {
+    const userId = req.decoded;
+    const groupId = req.params.id;
+    try {
+      const getAdmin = await pool.query(`DELETE FROM groups WHERE (id = ${groupId} AND admin = ${userId}) RETURNING *`);
+      if (getAdmin.rows[0] !== undefined) {
+        return res.status(200).send({
+          status: 'Successful',
+          message: 'Group successfully deleted',
+        });
+      }
+    } catch (err) {
+      return errorResponse(404, 'Invalid request', res);
+    }
+
+    return errorResponse(401, 'Unauthorized access', res);
+  }
+
+
 }
 
 export default EpicGroup;

--- a/Server/Router/DBRouters.js
+++ b/Server/Router/DBRouters.js
@@ -22,4 +22,5 @@ router.put('/user/update', Auth, Validator.validateProfile, DBUserController.upd
 router.post('/groups', Auth, Validator.validateNewGroup, groupController.newGroup);
 router.get('/groups', Auth, groupController.getGroup);
 router.patch('/groups/:id', Auth, Validator.validateUpdateGroup, groupController.updateName);
+router.delete('/groups/:id', Auth,  groupController.deleteGroup);
 export default router;

--- a/Server/Test/test.js
+++ b/Server/Test/test.js
@@ -539,4 +539,52 @@ describe('Epic Test', () => {
         });
     });
   });
+
+  describe('DELETE/Groups', () => {
+    it('should not give unauthorized user access', (done) => {
+      chai.request(app)
+        .delete('/api/v2/groups/5')
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(400);
+          expect(res.body.status).to.equal('Failure');
+          done();
+        });
+    });
+
+    it('should delete group you are an admin to', (done) => {
+      chai.request(app)
+        .delete('/api/v2/groups/2')
+        .set('token', userToken)
+        .send({ name: 'update group' })
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(200);
+          expect(res.body.status).to.equal('Successful');
+          done();
+        });
+    });
+
+    it('unauthorized users should not delete the group', (done) => {
+      chai.request(app)
+        .patch('/api/v2/groups/1')
+        .send({ name: 'update group' })
+        .set('token', userToken)
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(401);
+          expect(res.body.status).to.equal('Failure');
+          done();
+        });
+    });
+
+    // it('users should not edit the name of a group with wrong format of updated name', (done) => {
+    //   chai.request(app)
+    //     .patch('/api/v2/groups/3hj')
+    //     .send({ name: 'update group' })
+    //     .set('token', userToken)
+    //     .end((err, res) => {
+    //       expect(res.statusCode).to.equal(400);
+    //       expect(res.body.status).to.equal('Failure');
+    //       done();
+    //     });
+    // });
+  });
 });

--- a/Server/helper/db_query/createTables.js
+++ b/Server/helper/db_query/createTables.js
@@ -49,8 +49,9 @@ const groups = `CREATE TABLE IF NOT EXISTS
 
 const groupJoin = `CREATE TABLE IF NOT EXISTS
         joint(
-          group_id integer REFERENCES groups(id),
-          member integer NOT NULL
+          group_id integer NOT NULL,
+          member integer NOT NULL,
+          FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE
         );`;
 
 const create = `${groups}${groupJoin}${users}${messages}${read}`;


### PR DESCRIPTION
#### What does this PR do?
Gives a group admin access to delete a group

#### Description of Task to be completed?
1. Have the "DELETE'/api/v2/groups/group-id " endpoint working

#### How should this be manually tested?
After cloning the repo, cd into it and run "npm run startdev",
Using postman test the endpoint.
if successful, you'll get a response with a status code of 200 with a message 'Group successfully deleted.

#### What are the relevant pivotal tracker stories?
<a href = "https://www.pivotaltracker.com/story/show/164685665">#164685665</a>